### PR TITLE
Add simple docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,10 @@ debug/data/hrr.json
 debug/data/hsa.json
 debug/data/idaho.json
 debug/data/zips.json
-geojson-vt-dev.js
-geojson-vt.js
 node_modules
 coverage
 coverage.lcov
 .nyc_output
 .idea
 dist
+docs

--- a/debug/index.html
+++ b/debug/index.html
@@ -15,7 +15,7 @@
 </head>
 
 <body>
-    <script src='../geojson-vt-dev.js'></script>
+    <script src='../dist/geojson-vt-dev.js'></script>
     <script src="https://d3js.org/topojson.v1.min.js"></script>
     <canvas id="canvas"></canvas>
     <button id="back">&larr;</button>

--- a/debug/update.html
+++ b/debug/update.html
@@ -35,7 +35,7 @@
     </div>
 
     <script src="https://d3js.org/topojson.v1.min.js"></script>
-    <script src='../geojson-vt-dev.js'></script>
+    <script src='../dist/geojson-vt-dev.js'></script>
     <script src="viz-update.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "build": "rollup -c",
     "watch": "rollup -cw",
     "bench": "node bench/benchmark.js",
+    "docs": "mkdir -p docs && cp -r debug/* docs/ && find docs -name '*.html' -exec sed -i 's|../dist/geojson-vt-dev.js|https://unpkg.com/@maplibre/geojson-vt@latest/dist/geojson-vt.js|g' {} +",
     "prepublishOnly": "npm run test && npm run build"
   },
   "files": [


### PR DESCRIPTION
This will allow uploading the debug pages as an initial documentation.
Later on we could use typedoc when the library will use typescript to do the API documentation.