### PR TITLE
Move code to use named exports

### DIFF
--- a/src/clip.js
+++ b/src/clip.js
@@ -1,5 +1,5 @@
 
-import createFeature from './feature.js';
+import {createFeature} from './feature.js';
 
 /* clip features between two vertical or horizontal axis-parallel lines:
  *     |        |
@@ -11,7 +11,7 @@ import createFeature from './feature.js';
  * axis: 0 for x, 1 for y
  * minAll and maxAll: minimum and maximum coordinate value for all features
  */
-export default function clip(features, scale, k1, k2, axis, minAll, maxAll, options) {
+export function clip(features, scale, k1, k2, axis, minAll, maxAll, options) {
     k1 /= scale;
     k2 /= scale;
 

--- a/src/convert.js
+++ b/src/convert.js
@@ -1,10 +1,14 @@
 
-import simplify from './simplify.js';
-import createFeature from './feature.js';
+import {simplify} from './simplify.js';
+import {createFeature} from './feature.js';
 
-// converts GeoJSON feature into an intermediate projected JSON vector format with simplification data
-
-export default function convert(data, options) {
+/**
+ * converts GeoJSON feature into an intermediate projected JSON vector format with simplification data
+ * @param {*} data
+ * @param {*} options
+ * @returns
+ */
+export function convert(data, options) {
     const features = [];
     if (data.type === 'FeatureCollection') {
         for (let i = 0; i < data.features.length; i++) {

--- a/src/difference.js
+++ b/src/difference.js
@@ -1,5 +1,5 @@
-import convert from './convert.js'; // GeoJSON conversion and preprocessing
-import wrap from './wrap.js';       // date line processing
+import {convert} from './convert.js'; // GeoJSON conversion and preprocessing
+import {wrap} from './wrap.js';       // date line processing
 
 // This file provides a set of helper functions for managing "diffs" (changes)
 // to GeoJSON data structures. These diffs describe additions, removals,

--- a/src/feature.js
+++ b/src/feature.js
@@ -1,5 +1,5 @@
 
-export default function createFeature(id, type, geom, tags) {
+export function createFeature(id, type, geom, tags) {
     const feature = {
         id: id == null ? null : id,
         type,

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 
-import convert from './convert.js';              // GeoJSON conversion and preprocessing
-import clip from './clip.js';                    // stripe clipping algorithm
-import wrap from './wrap.js';                    // date line processing
-import transform from './transform.js';          // coordinate transformation
-import createTile from './tile.js';              // final simplified tile generation
+import {convert} from './convert.js';              // GeoJSON conversion and preprocessing
+import {clip} from './clip.js';                    // stripe clipping algorithm
+import {wrap} from './wrap.js';                    // date line processing
+import {transformTile} from './transform.js';          // coordinate transformation
+import {createTile} from './tile.js';              // final simplified tile generation
 import {applySourceDiff} from './difference.js'; // diff utilities
 
 const defaultOptions = {
@@ -176,7 +176,7 @@ class GeoJSONVT {
         x = (x + z2) & (z2 - 1); // wrap tile x coordinate
 
         const id = toID(z, x, y);
-        if (this.tiles[id]) return transform(this.tiles[id], extent);
+        if (this.tiles[id]) return transformTile(this.tiles[id], extent);
 
         if (debug > 1) console.log('drilling down to z%d-%d-%d', z, x, y);
 
@@ -202,7 +202,7 @@ class GeoJSONVT {
         this.splitTile(parent.source, z0, x0, y0, z, x, y);
         if (debug > 1) console.timeEnd('drilling down');
 
-        return this.tiles[id] ? transform(this.tiles[id], extent) : null;
+        return this.tiles[id] ? transformTile(this.tiles[id], extent) : null;
     }
 
     // invalidates (removes) tiles affected by the provided features

--- a/src/simplify.js
+++ b/src/simplify.js
@@ -1,7 +1,11 @@
-
-// calculate simplification data using optimized Douglas-Peucker algorithm
-
-export default function simplify(coords, first, last, sqTolerance) {
+/**
+ * calculate simplification data using optimized Douglas-Peucker algorithm
+ * @param {*} coords
+ * @param {*} first
+ * @param {*} last
+ * @param {*} sqTolerance
+ */
+export function simplify(coords, first, last, sqTolerance) {
     let maxSqDist = sqTolerance;
     const mid = first + ((last - first) >> 1);
     let minPosToMid = last - first;

--- a/src/tile.js
+++ b/src/tile.js
@@ -1,5 +1,14 @@
 
-export default function createTile(features, z, tx, ty, options) {
+/**
+ * Creates a tile object from the given features
+ * @param {*} features - the features to include in the tile
+ * @param {*} z
+ * @param {*} tx
+ * @param {*} ty
+ * @param {*} options
+ * @returns the created tile
+ */
+export function createTile(features, z, tx, ty, options) {
     const tolerance = z === options.maxZoom ? 0 : options.tolerance / ((1 << z) * options.extent);
     const tile = {
         features: [],

--- a/src/transform.js
+++ b/src/transform.js
@@ -1,7 +1,12 @@
 
-// Transforms the coordinates of each feature in the given tile from
-// mercator-projected space into (extent x extent) tile space.
-export default function transformTile(tile, extent) {
+/**
+ * Transforms the coordinates of each feature in the given tile from
+ * mercator-projected space into (extent x extent) tile space.
+ * @param {*} tile - the tile to transform, this gets modified in place
+ * @param {*} extent - the tile extent (usually 4096)
+ * @returns the transformed tile
+ */
+export function transformTile(tile, extent) {
     if (tile.transformed) return tile;
 
     const z2 = 1 << tile.z;

--- a/src/wrap.js
+++ b/src/wrap.js
@@ -1,8 +1,8 @@
 
-import clip from './clip.js';
-import createFeature from './feature.js';
+import {clip} from './clip.js';
+import {createFeature} from './feature.js';
 
-export default function wrap(features, options) {
+export function wrap(features, options) {
     const buffer = options.buffer / options.extent;
     let merged = features;
     const left  = clip(features, 1, -1 - buffer, buffer,     0, -1, 2, options); // left world copy

--- a/test/test-clip.js
+++ b/test/test-clip.js
@@ -2,7 +2,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import clip from '../src/clip.js';
+import {clip} from '../src/clip.js';
 
 /* eslint @stylistic/comma-spacing: 0 */
 

--- a/test/test-simplify.js
+++ b/test/test-simplify.js
@@ -2,7 +2,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import simplify from '../src/simplify.js';
+import {simplify} from '../src/simplify.js';
 
 /* eslint @stylistic/comma-spacing: 0, no-shadow: 0 */
 


### PR DESCRIPTION
This moves the code to use named exports instead of default export.
This helps the IDE to understand that something is referenced, and where, this will help me better understand how to type the methods.