### PR TITLE
Add `worldCopies` option

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -54,7 +54,7 @@ export type GeoJSONVTOptions = {
      */
     debug?: number;
     /**
-     * Whether wrapped features should overlap at the antimeridian.
+     * Whether to duplicate features near the antimeridian into adjacent world copies for seamless wrapping.
      * @default true
      */
     worldCopies?: boolean;

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -54,6 +54,11 @@ export type GeoJSONVTOptions = {
      */
     debug?: number;
     /**
+     * Whether wrapped features should overlap at the antimeridian.
+     * @default true
+     */
+    worldCopies?: boolean;
+    /**
      * Enable Supercluster for point features.
      * @default false
      */

--- a/src/geojsonvt.ts
+++ b/src/geojsonvt.ts
@@ -7,20 +7,20 @@ import {TileIndex} from './tile-index';
 import type {ClusterOrPointFeature, GeoJSONVTTileIndex, GeoJSONVTInternalFeature, GeoJSONVTOptions, GeoJSONVTTile, SuperclusterOptions} from './definitions';
 
 export const defaultOptions: GeoJSONVTOptions = {
-  maxZoom: 14,
-  indexMaxZoom: 5,
-  indexMaxPoints: 100000,
-  tolerance: 3,
-  extent: 4096,
-  buffer: 64,
-  lineMetrics: false,
-  promoteId: null,
-  generateId: false,
-  updateable: false,
-  cluster: false,
-  clusterOptions: defaultClusterOptions,
-  worldCopies: true,
-  debug: 0
+    maxZoom: 14,
+    indexMaxZoom: 5,
+    indexMaxPoints: 100000,
+    tolerance: 3,
+    extent: 4096,
+    buffer: 64,
+    lineMetrics: false,
+    promoteId: null,
+    generateId: false,
+    updateable: false,
+    cluster: false,
+    clusterOptions: defaultClusterOptions,
+    worldCopies: true,
+    debug: 0
 };
 
 /**
@@ -28,183 +28,183 @@ export const defaultOptions: GeoJSONVTOptions = {
  */
 export class GeoJSONVT {
 
-  /**
-   * @internal
-   * This is for the tests
-   */
-  public get tiles() {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (this.tileIndex as any)?.tiles ?? {};
-  }
-  /**
-   * @internal
-   * This is for the tests
-   */
-  public get stats() {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (this.tileIndex as any).stats;
-  }
-  /**
-   * @internal
-   * This is for the tests
-   */
-  public get total() {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (this.tileIndex as any).total;
-  }
+    /** 
+     * @internal
+     * This is for the tests
+     */
+    public get tiles() {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (this.tileIndex as any)?.tiles ?? {};
+    }
+    /** 
+     * @internal
+     * This is for the tests
+     */
+    public get stats() {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (this.tileIndex as any).stats;
+    }
+     /** 
+     * @internal
+     * This is for the tests
+     */
+    public get total() {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (this.tileIndex as any).total;
+    }
 
-  private options: GeoJSONVTOptions;
+    private options: GeoJSONVTOptions;
+    
+    private source?: GeoJSONVTInternalFeature[];
+    private tileIndex: GeoJSONVTTileIndex;
 
-  private source?: GeoJSONVTInternalFeature[];
-  private tileIndex: GeoJSONVTTileIndex;
+    constructor(data: GeoJSON.GeoJSON, options?: GeoJSONVTOptions) {
+        options = this.options = Object.assign({}, defaultOptions, options);
 
-  constructor(data: GeoJSON.GeoJSON, options?: GeoJSONVTOptions) {
-    options = this.options = Object.assign({}, defaultOptions, options);
-
-    const debug = options.debug;
+        const debug = options.debug;
 
         if (debug) console.time('preprocess data');
 
         if (options.maxZoom < 0 || options.maxZoom > 24) throw new Error('maxZoom should be in the 0-24 range');
         if (options.promoteId && options.generateId) throw new Error('promoteId and generateId cannot be used together.');
 
-    // projects and adds simplification info
-    let features = convertToInternal(data, options);
+        // projects and adds simplification info
+        let features = convertToInternal(data, options);
 
-    if (debug) {
+        if (debug) {
             console.timeEnd('preprocess data');
             console.log('index: maxZoom: %d, maxPoints: %d', options.indexMaxZoom, options.indexMaxPoints);
             console.time('generate tiles');
+        }
+
+        // wraps features (ie extreme west and extreme east)
+        features = wrap(features, options);
+
+        // for updateable indexes, store a copy of the original simplified features
+        if (options.updateable) {
+            this.source = features;
+        }
+
+        this.initializeIndex(features, options);
     }
-
-    // wraps features (ie extreme west and extreme east)
-    features = wrap(features, options);
-
-    // for updateable indexes, store a copy of the original simplified features
-    if (options.updateable) {
-      this.source = features;
-    }
-
-    this.initializeIndex(features, options);
-  }
 
     private initializeIndex(features: GeoJSONVTInternalFeature[], options: GeoJSONVTOptions) {
         this.tileIndex = options.cluster ? new ClusterTileIndex(options.clusterOptions) : new TileIndex(options);
-    if (!features.length) return;
-    this.tileIndex.initialize(features);
-  }
+        if (!features.length) return;
+        this.tileIndex.initialize(features);
+    }
 
-  /**
-   * Given z, x, and y tile coordinates, returns the corresponding tile with geometries in tile coordinates, much like MVT data is stored.
-   * @param z - tile zoom level
-   * @param x - tile x coordinate
-   * @param y - tile y coordinate
-   * @returns the transformed tile or null if not found
-   */
+    /**
+     * Given z, x, and y tile coordinates, returns the corresponding tile with geometries in tile coordinates, much like MVT data is stored.
+     * @param z - tile zoom level
+     * @param x - tile x coordinate
+     * @param y - tile y coordinate
+     * @returns the transformed tile or null if not found
+     */
     getTile(z: number | string, x: number | string, y: number | string): GeoJSONVTTile | null {
-    z = +z;
-    x = +x;
-    y = +y;
+        z = +z;
+        x = +x;
+        y = +y;
 
-    if (z < 0 || z > 24) return null;
+        if (z < 0 || z > 24) return null;
 
-    return this.tileIndex.getTile(z, x, y);
-  }
+        return this.tileIndex.getTile(z, x, y);
+    }
 
-  /**
-   * Updates the source data feature set using a {@link GeoJSONVTSourceDiff}
-   * @param diff - the source diff object
-   */
+    /**
+     * Updates the source data feature set using a {@link GeoJSONVTSourceDiff}
+     * @param diff - the source diff object
+     */
     updateData(diff: GeoJSONVTSourceDiff, filter?: (feature: GeoJSON.Feature) => boolean) {
-    const options = this.options;
+        const options = this.options;
 
         if (!options.updateable) throw new Error('to update tile geojson `updateable` option must be set to true');
 
-    // apply diff and collect affected features and updated source that will be used to invalidate tiles
+        // apply diff and collect affected features and updated source that will be used to invalidate tiles
         let {affected, source} = applySourceDiff(this.source, diff, options);
 
-    if (filter) {
+        if (filter) {
             ({affected, source} = this.filterUpdate(source, affected, filter));
+        }
+
+        // nothing has changed
+        if (!affected.length) return;
+
+        // update source with new simplified feature set
+        this.source = source;
+
+        this.tileIndex.updateIndex(source, affected, options);
     }
 
-    // nothing has changed
-    if (!affected.length) return;
-
-    // update source with new simplified feature set
-    this.source = source;
-
-    this.tileIndex.updateIndex(source, affected, options);
-  }
-
-  /**
-   * Filter an update using a predicate function. Returns the affected and updated source features.
-   */
+    /**
+     * Filter an update using a predicate function. Returns the affected and updated source features.
+     */
     private filterUpdate(source: GeoJSONVTInternalFeature[], affected: GeoJSONVTInternalFeature[], predicate: (feature: GeoJSON.Feature) => boolean) {
-    const removeIds = new Set();
+        const removeIds = new Set();
 
-    for (const feature of source) {
-      if (feature.id == undefined) continue;
-      if (predicate(featureToGeoJSON(feature))) continue;
-      affected.push(feature);
-      removeIds.add(feature.id);
-    }
+        for (const feature of source) {
+            if (feature.id == undefined) continue;
+            if (predicate(featureToGeoJSON(feature))) continue;
+            affected.push(feature);
+            removeIds.add(feature.id);
+        }
         source = source.filter(feature => !removeIds.has(feature.id));
 
         return {affected, source};
-  }
-
-  /**
-   * Returns source data as GeoJSON - only available when `updateable` option is set to true.
-   */
-  getData(): GeoJSON.GeoJSON {
-        if (!this.options.updateable) throw new Error('to retrieve data the `updateable` option must be set to true');
-    return convertToGeoJSON(this.source);
-  }
-
-  /**
-   * Update supercluster options and regenerate the index.
-   * @param cluster - whether to enable clustering
-   * @param clusterOptions - {@link SuperclusterOptions}
-   */
-  updateClusterOptions(cluster: boolean, clusterOptions: SuperclusterOptions) {
-    const wasCluster = this.options.cluster;
-    this.options.cluster = cluster;
-    this.options.clusterOptions = clusterOptions;
-
-    if (wasCluster == cluster) {
-      this.tileIndex.updateIndex(this.source, [], this.options);
-      return;
     }
 
-    this.initializeIndex(this.source, this.options);
-  }
+    /**
+     * Returns source data as GeoJSON - only available when `updateable` option is set to true.
+     */
+    getData(): GeoJSON.GeoJSON {
+        if (!this.options.updateable) throw new Error('to retrieve data the `updateable` option must be set to true');
+        return convertToGeoJSON(this.source);
+    }
+    
+    /**
+     * Update supercluster options and regenerate the index.
+     * @param cluster - whether to enable clustering
+     * @param clusterOptions - {@link SuperclusterOptions}
+     */
+    updateClusterOptions(cluster: boolean, clusterOptions: SuperclusterOptions) {
+        const wasCluster = this.options.cluster;
+        this.options.cluster = cluster;
+        this.options.clusterOptions = clusterOptions;
 
-  /**
-   * Returns the zoom level at which a cluster expands into multiple children.
-   * @param clusterId - The target cluster id.
-   * @returns the expansion zoom or null in case of non-clustered source
-   */
-  getClusterExpansionZoom(clusterId: number): number | null {
-    return this.tileIndex.getClusterExpansionZoom(clusterId);
-  }
+        if (wasCluster == cluster) {
+            this.tileIndex.updateIndex(this.source, [], this.options);
+            return;    
+        }
 
-  /**
-   * Returns the immediate children (clusters or points) of a cluster as GeoJSON.
-   * @param clusterId - The target cluster id.
-   * @returns the immediate children or null in case of non-clustered source
-   */
-  getClusterChildren(clusterId: number): ClusterOrPointFeature[] | null {
-    return this.tileIndex.getChildren(clusterId);
-  }
+        this.initializeIndex(this.source, this.options);
+    }
 
-  /**
-   * Returns leaf point features under a cluster, paginated by `limit` and `offset`.
-   * @param clusterId - The target cluster id.
-   * @param limit - Maximum number of points to return (defaults to `10`).
-   * @param offset - Number of points to skip before collecting results (defaults to `0`).
-   * @returns leaf point features under a cluster or null in case of non-clustered source
-   */
+    /**
+     * Returns the zoom level at which a cluster expands into multiple children.
+     * @param clusterId - The target cluster id.
+     * @returns the expansion zoom or null in case of non-clustered source
+     */
+    getClusterExpansionZoom(clusterId: number): number | null {
+        return this.tileIndex.getClusterExpansionZoom(clusterId);
+    }
+
+    /**
+     * Returns the immediate children (clusters or points) of a cluster as GeoJSON.
+     * @param clusterId - The target cluster id.
+     * @returns the immediate children or null in case of non-clustered source
+     */
+    getClusterChildren(clusterId: number): ClusterOrPointFeature[] | null {
+        return this.tileIndex.getChildren(clusterId);
+    }
+
+    /**
+     * Returns leaf point features under a cluster, paginated by `limit` and `offset`.
+     * @param clusterId - The target cluster id.
+     * @param limit - Maximum number of points to return (defaults to `10`).
+     * @param offset - Number of points to skip before collecting results (defaults to `0`).
+     * @returns leaf point features under a cluster or null in case of non-clustered source
+     */
     getClusterLeaves(clusterId: number, limit: number, offset: number): GeoJSON.Feature<GeoJSON.Point>[] | null {
-    return this.tileIndex.getLeaves(clusterId, limit, offset);
-  }
+        return this.tileIndex.getLeaves(clusterId, limit, offset);
+    }
 }

--- a/src/geojsonvt.ts
+++ b/src/geojsonvt.ts
@@ -7,19 +7,20 @@ import {TileIndex} from './tile-index';
 import type {ClusterOrPointFeature, GeoJSONVTTileIndex, GeoJSONVTInternalFeature, GeoJSONVTOptions, GeoJSONVTTile, SuperclusterOptions} from './definitions';
 
 export const defaultOptions: GeoJSONVTOptions = {
-    maxZoom: 14,
-    indexMaxZoom: 5,
-    indexMaxPoints: 100000,
-    tolerance: 3,
-    extent: 4096,
-    buffer: 64,
-    lineMetrics: false,
-    promoteId: null,
-    generateId: false,
-    updateable: false,
-    cluster: false,
-    clusterOptions: defaultClusterOptions,
-    debug: 0
+  maxZoom: 14,
+  indexMaxZoom: 5,
+  indexMaxPoints: 100000,
+  tolerance: 3,
+  extent: 4096,
+  buffer: 64,
+  lineMetrics: false,
+  promoteId: null,
+  generateId: false,
+  updateable: false,
+  cluster: false,
+  clusterOptions: defaultClusterOptions,
+  worldCopies: true,
+  debug: 0
 };
 
 /**
@@ -27,183 +28,183 @@ export const defaultOptions: GeoJSONVTOptions = {
  */
 export class GeoJSONVT {
 
-    /** 
-     * @internal
-     * This is for the tests
-     */
-    public get tiles() {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return (this.tileIndex as any)?.tiles ?? {};
-    }
-    /** 
-     * @internal
-     * This is for the tests
-     */
-    public get stats() {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return (this.tileIndex as any).stats;
-    }
-     /** 
-     * @internal
-     * This is for the tests
-     */
-    public get total() {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return (this.tileIndex as any).total;
-    }
+  /**
+   * @internal
+   * This is for the tests
+   */
+  public get tiles() {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (this.tileIndex as any)?.tiles ?? {};
+  }
+  /**
+   * @internal
+   * This is for the tests
+   */
+  public get stats() {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (this.tileIndex as any).stats;
+  }
+  /**
+   * @internal
+   * This is for the tests
+   */
+  public get total() {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (this.tileIndex as any).total;
+  }
 
-    private options: GeoJSONVTOptions;
-    
-    private source?: GeoJSONVTInternalFeature[];
-    private tileIndex: GeoJSONVTTileIndex;
+  private options: GeoJSONVTOptions;
 
-    constructor(data: GeoJSON.GeoJSON, options?: GeoJSONVTOptions) {
-        options = this.options = Object.assign({}, defaultOptions, options);
+  private source?: GeoJSONVTInternalFeature[];
+  private tileIndex: GeoJSONVTTileIndex;
 
-        const debug = options.debug;
+  constructor(data: GeoJSON.GeoJSON, options?: GeoJSONVTOptions) {
+    options = this.options = Object.assign({}, defaultOptions, options);
+
+    const debug = options.debug;
 
         if (debug) console.time('preprocess data');
 
         if (options.maxZoom < 0 || options.maxZoom > 24) throw new Error('maxZoom should be in the 0-24 range');
         if (options.promoteId && options.generateId) throw new Error('promoteId and generateId cannot be used together.');
 
-        // projects and adds simplification info
-        let features = convertToInternal(data, options);
+    // projects and adds simplification info
+    let features = convertToInternal(data, options);
 
-        if (debug) {
+    if (debug) {
             console.timeEnd('preprocess data');
             console.log('index: maxZoom: %d, maxPoints: %d', options.indexMaxZoom, options.indexMaxPoints);
             console.time('generate tiles');
-        }
-
-        // wraps features (ie extreme west and extreme east)
-        features = wrap(features, options);
-
-        // for updateable indexes, store a copy of the original simplified features
-        if (options.updateable) {
-            this.source = features;
-        }
-
-        this.initializeIndex(features, options);
     }
+
+    // wraps features (ie extreme west and extreme east)
+    features = wrap(features, options);
+
+    // for updateable indexes, store a copy of the original simplified features
+    if (options.updateable) {
+      this.source = features;
+    }
+
+    this.initializeIndex(features, options);
+  }
 
     private initializeIndex(features: GeoJSONVTInternalFeature[], options: GeoJSONVTOptions) {
         this.tileIndex = options.cluster ? new ClusterTileIndex(options.clusterOptions) : new TileIndex(options);
-        if (!features.length) return;
-        this.tileIndex.initialize(features);
-    }
+    if (!features.length) return;
+    this.tileIndex.initialize(features);
+  }
 
-    /**
-     * Given z, x, and y tile coordinates, returns the corresponding tile with geometries in tile coordinates, much like MVT data is stored.
-     * @param z - tile zoom level
-     * @param x - tile x coordinate
-     * @param y - tile y coordinate
-     * @returns the transformed tile or null if not found
-     */
+  /**
+   * Given z, x, and y tile coordinates, returns the corresponding tile with geometries in tile coordinates, much like MVT data is stored.
+   * @param z - tile zoom level
+   * @param x - tile x coordinate
+   * @param y - tile y coordinate
+   * @returns the transformed tile or null if not found
+   */
     getTile(z: number | string, x: number | string, y: number | string): GeoJSONVTTile | null {
-        z = +z;
-        x = +x;
-        y = +y;
+    z = +z;
+    x = +x;
+    y = +y;
 
-        if (z < 0 || z > 24) return null;
+    if (z < 0 || z > 24) return null;
 
-        return this.tileIndex.getTile(z, x, y);
-    }
+    return this.tileIndex.getTile(z, x, y);
+  }
 
-    /**
-     * Updates the source data feature set using a {@link GeoJSONVTSourceDiff}
-     * @param diff - the source diff object
-     */
+  /**
+   * Updates the source data feature set using a {@link GeoJSONVTSourceDiff}
+   * @param diff - the source diff object
+   */
     updateData(diff: GeoJSONVTSourceDiff, filter?: (feature: GeoJSON.Feature) => boolean) {
-        const options = this.options;
+    const options = this.options;
 
         if (!options.updateable) throw new Error('to update tile geojson `updateable` option must be set to true');
 
-        // apply diff and collect affected features and updated source that will be used to invalidate tiles
+    // apply diff and collect affected features and updated source that will be used to invalidate tiles
         let {affected, source} = applySourceDiff(this.source, diff, options);
 
-        if (filter) {
+    if (filter) {
             ({affected, source} = this.filterUpdate(source, affected, filter));
-        }
-
-        // nothing has changed
-        if (!affected.length) return;
-
-        // update source with new simplified feature set
-        this.source = source;
-
-        this.tileIndex.updateIndex(source, affected, options);
     }
 
-    /**
-     * Filter an update using a predicate function. Returns the affected and updated source features.
-     */
-    private filterUpdate(source: GeoJSONVTInternalFeature[], affected: GeoJSONVTInternalFeature[], predicate: (feature: GeoJSON.Feature) => boolean) {
-        const removeIds = new Set();
+    // nothing has changed
+    if (!affected.length) return;
 
-        for (const feature of source) {
-            if (feature.id == undefined) continue;
-            if (predicate(featureToGeoJSON(feature))) continue;
-            affected.push(feature);
-            removeIds.add(feature.id);
-        }
+    // update source with new simplified feature set
+    this.source = source;
+
+    this.tileIndex.updateIndex(source, affected, options);
+  }
+
+  /**
+   * Filter an update using a predicate function. Returns the affected and updated source features.
+   */
+    private filterUpdate(source: GeoJSONVTInternalFeature[], affected: GeoJSONVTInternalFeature[], predicate: (feature: GeoJSON.Feature) => boolean) {
+    const removeIds = new Set();
+
+    for (const feature of source) {
+      if (feature.id == undefined) continue;
+      if (predicate(featureToGeoJSON(feature))) continue;
+      affected.push(feature);
+      removeIds.add(feature.id);
+    }
         source = source.filter(feature => !removeIds.has(feature.id));
 
         return {affected, source};
-    }
+  }
 
-    /**
-     * Returns source data as GeoJSON - only available when `updateable` option is set to true.
-     */
-    getData(): GeoJSON.GeoJSON {
+  /**
+   * Returns source data as GeoJSON - only available when `updateable` option is set to true.
+   */
+  getData(): GeoJSON.GeoJSON {
         if (!this.options.updateable) throw new Error('to retrieve data the `updateable` option must be set to true');
-        return convertToGeoJSON(this.source);
-    }
-    
-    /**
-     * Update supercluster options and regenerate the index.
-     * @param cluster - whether to enable clustering
-     * @param clusterOptions - {@link SuperclusterOptions}
-     */
-    updateClusterOptions(cluster: boolean, clusterOptions: SuperclusterOptions) {
-        const wasCluster = this.options.cluster;
-        this.options.cluster = cluster;
-        this.options.clusterOptions = clusterOptions;
+    return convertToGeoJSON(this.source);
+  }
 
-        if (wasCluster == cluster) {
-            this.tileIndex.updateIndex(this.source, [], this.options);
-            return;    
-        }
+  /**
+   * Update supercluster options and regenerate the index.
+   * @param cluster - whether to enable clustering
+   * @param clusterOptions - {@link SuperclusterOptions}
+   */
+  updateClusterOptions(cluster: boolean, clusterOptions: SuperclusterOptions) {
+    const wasCluster = this.options.cluster;
+    this.options.cluster = cluster;
+    this.options.clusterOptions = clusterOptions;
 
-        this.initializeIndex(this.source, this.options);
+    if (wasCluster == cluster) {
+      this.tileIndex.updateIndex(this.source, [], this.options);
+      return;
     }
 
-    /**
-     * Returns the zoom level at which a cluster expands into multiple children.
-     * @param clusterId - The target cluster id.
-     * @returns the expansion zoom or null in case of non-clustered source
-     */
-    getClusterExpansionZoom(clusterId: number): number | null {
-        return this.tileIndex.getClusterExpansionZoom(clusterId);
-    }
+    this.initializeIndex(this.source, this.options);
+  }
 
-    /**
-     * Returns the immediate children (clusters or points) of a cluster as GeoJSON.
-     * @param clusterId - The target cluster id.
-     * @returns the immediate children or null in case of non-clustered source
-     */
-    getClusterChildren(clusterId: number): ClusterOrPointFeature[] | null {
-        return this.tileIndex.getChildren(clusterId);
-    }
+  /**
+   * Returns the zoom level at which a cluster expands into multiple children.
+   * @param clusterId - The target cluster id.
+   * @returns the expansion zoom or null in case of non-clustered source
+   */
+  getClusterExpansionZoom(clusterId: number): number | null {
+    return this.tileIndex.getClusterExpansionZoom(clusterId);
+  }
 
-    /**
-     * Returns leaf point features under a cluster, paginated by `limit` and `offset`.
-     * @param clusterId - The target cluster id.
-     * @param limit - Maximum number of points to return (defaults to `10`).
-     * @param offset - Number of points to skip before collecting results (defaults to `0`).
-     * @returns leaf point features under a cluster or null in case of non-clustered source
-     */
+  /**
+   * Returns the immediate children (clusters or points) of a cluster as GeoJSON.
+   * @param clusterId - The target cluster id.
+   * @returns the immediate children or null in case of non-clustered source
+   */
+  getClusterChildren(clusterId: number): ClusterOrPointFeature[] | null {
+    return this.tileIndex.getChildren(clusterId);
+  }
+
+  /**
+   * Returns leaf point features under a cluster, paginated by `limit` and `offset`.
+   * @param clusterId - The target cluster id.
+   * @param limit - Maximum number of points to return (defaults to `10`).
+   * @param offset - Number of points to skip before collecting results (defaults to `0`).
+   * @returns leaf point features under a cluster or null in case of non-clustered source
+   */
     getClusterLeaves(clusterId: number, limit: number, offset: number): GeoJSON.Feature<GeoJSON.Point>[] | null {
-        return this.tileIndex.getLeaves(clusterId, limit, offset);
-    }
+    return this.tileIndex.getLeaves(clusterId, limit, offset);
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,14 +5,15 @@ import type {KDBushWithData} from './cluster-tile-index';
 import {GeoJSONVT} from './geojsonvt';
 import {ClusterTileIndex} from './cluster-tile-index';
 import {geoJSONToTile} from './geojson-to-tile';
-import {GEOJSONVT_CLIP_START, GEOJSONVT_CLIP_END} from './tile';
+import {GEOJSONVT_CLIP_START, GEOJSONVT_CLIP_END, GEOJSONVT_ANTIMERIDIAN_CLIP} from './tile';
 
 export {
     GeoJSONVT,
     ClusterTileIndex as Supercluster,
     geoJSONToTile,
     GEOJSONVT_CLIP_START,
-    GEOJSONVT_CLIP_END
+    GEOJSONVT_CLIP_END,
+    GEOJSONVT_ANTIMERIDIAN_CLIP
 }
 
 export type {

--- a/src/tile.ts
+++ b/src/tile.ts
@@ -2,6 +2,7 @@ import type { GeoJSONVTInternalFeature, GeoJSONVTInternalLineStringFeature, GeoJ
 
 export const GEOJSONVT_CLIP_START = 'geojsonvt_clip_start';
 export const GEOJSONVT_CLIP_END = 'geojsonvt_clip_end';
+export const GEOJSONVT_ANTIMERIDIAN_CLIP = 'geojsonvt_antimeridian_clip';
 
 /**
  * Creates a tile object from the given features

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -3,10 +3,7 @@ import {AxisType, clip} from './clip';
 import type { GeoJSONVTInternalFeature, GeoJSONVTOptions, StartEndSizeArray } from './definitions';
 import {createFeature} from './feature';
 
-export function wrap(
-  features: GeoJSONVTInternalFeature[],
-  options: GeoJSONVTOptions,
-): GeoJSONVTInternalFeature[] {
+export function wrap(features: GeoJSONVTInternalFeature[], options: GeoJSONVTOptions): GeoJSONVTInternalFeature[] {
   if (options.worldCopies) {
     const buffer = options.buffer / options.extent;
     let merged = features;
@@ -47,61 +44,61 @@ export function wrap(
 }
 
 function shiftFeatureCoords(features: GeoJSONVTInternalFeature[], offset: number): GeoJSONVTInternalFeature[] {
-  const newFeatures = [];
+    const newFeatures = [];
 
-  for (const feature of features) {
-    switch (feature.type) {
+    for (const feature of features) {
+        switch (feature.type) {
             case 'Point':
             case 'MultiPoint':
             case 'LineString': {
-        const newGeometry = shiftCoords(feature.geometry, offset);
+                const newGeometry = shiftCoords(feature.geometry, offset);
 
                 newFeatures.push(createFeature(feature.id, feature.type, newGeometry, feature.tags));
-        continue;
-      }
+                continue;
+            }
 
             case 'MultiLineString':
             case 'Polygon': {
-        const newGeometry = [];
-        for (const line of feature.geometry) {
-          newGeometry.push(shiftCoords(line, offset));
-        }
+                const newGeometry = [];
+                for (const line of feature.geometry) {
+                    newGeometry.push(shiftCoords(line, offset));
+                }
 
                 newFeatures.push(createFeature(feature.id, feature.type, newGeometry, feature.tags));
-        continue;
-      }
+                continue;
+            }
 
             case 'MultiPolygon': {
-        const newGeometry = [];
-        for (const polygon of feature.geometry) {
-          const newPolygon = [];
-          for (const line of polygon) {
-            newPolygon.push(shiftCoords(line, offset));
-          }
-          newGeometry.push(newPolygon);
-        }
+                const newGeometry = [];
+                for (const polygon of feature.geometry) {
+                    const newPolygon = [];
+                    for (const line of polygon) {
+                        newPolygon.push(shiftCoords(line, offset));
+                    }
+                    newGeometry.push(newPolygon);
+                }
 
                 newFeatures.push(createFeature(feature.id, feature.type, newGeometry, feature.tags));
-        continue;
-      }
+                continue;
+            }
+        }
     }
-  }
 
-  return newFeatures;
+    return newFeatures;
 }
 
 function shiftCoords(points: StartEndSizeArray, offset: number): number[] | StartEndSizeArray {
-  const newPoints: StartEndSizeArray = [];
-  newPoints.size = points.size;
+    const newPoints: StartEndSizeArray = [];
+    newPoints.size = points.size;
 
-  if (points.start !== undefined) {
-    newPoints.start = points.start;
-    newPoints.end = points.end;
-  }
+    if (points.start !== undefined) {
+        newPoints.start = points.start;
+        newPoints.end = points.end;
+    }
 
-  for (let i = 0; i < points.length; i += 3) {
-    newPoints.push(points[i] + offset, points[i + 1], points[i + 2]);
-  }
+    for (let i = 0; i < points.length; i += 3) {
+        newPoints.push(points[i] + offset, points[i + 1], points[i + 2]);
+    }
 
-  return newPoints;
+    return newPoints;
 }

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -25,7 +25,7 @@ export function wrap(features: GeoJSONVTInternalFeature[], options: GeoJSONVTOpt
     const center = clip(features, 1, 0, 1, AxisType.X, -1, 2, options);
     if (center) result.push(...center);
 
-    // Filters prevent duplicates at the antimeridian: clip()'s bounds are inclusive, 
+    // Prevent duplicates at the antimeridian, because clip()'s bounds are inclusive, 
     // so features with maxX === 1 must be routed to the right pass only.
     const rightCandidates = features.filter(f => f.maxX > 1 || f.minX >= 1);
     const right = rightCandidates.length

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -2,6 +2,7 @@
 import {AxisType, clip} from './clip';
 import type { GeoJSONVTInternalFeature, GeoJSONVTOptions, StartEndSizeArray } from './definitions';
 import {createFeature} from './feature';
+import {GEOJSONVT_ANTIMERIDIAN_CLIP} from './tile';
 
 export function wrap(features: GeoJSONVTInternalFeature[], options: GeoJSONVTOptions): GeoJSONVTInternalFeature[] {
   if (options.worldCopies) {
@@ -20,7 +21,16 @@ export function wrap(features: GeoJSONVTInternalFeature[], options: GeoJSONVTOpt
 
     return merged;
   } else {
-    // Prevent duplicates at the antimeridian, because clip()'s bounds are inclusive, 
+    // Tag crossing features so consumers can recognize the synthetic edges
+    // along x=0 / x=1 introduced by the clips below.
+    for (const feature of features) {
+      if (feature.minX < 0 || feature.maxX > 1) {
+        feature.tags = feature.tags || {};
+        feature.tags[GEOJSONVT_ANTIMERIDIAN_CLIP] = true;
+      }
+    }
+
+    // Prevent duplicates at the antimeridian, because clip()'s bounds are inclusive,
     // so features with maxX === 1 must be routed to the right pass only.
     const leftCandidates  = features.filter(f => f.minX < 0);
     const rightCandidates = features.filter(f => f.maxX > 1 || f.minX >= 1);

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -28,6 +28,8 @@ export function wrap(
     const center = clip(features, 1, 0, 1, AxisType.X, -1, 2, options);
     if (center) result.push(...center);
 
+    // Filters prevent duplicates at the antimeridian: clip()'s bounds are inclusive, 
+    // so features with maxX === 1 must be routed to the right pass only.
     const rightCandidates = features.filter(f => f.maxX > 1 || f.minX >= 1);
     const right = rightCandidates.length
       ? clip(rightCandidates, 1, 1, 3, AxisType.X, -1, 2, options)

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -28,10 +28,16 @@ export function wrap(
     const center = clip(features, 1, 0, 1, AxisType.X, -1, 2, options);
     if (center) result.push(...center);
 
-    const right = clip(features, 1, 1, 3, AxisType.X, -1, 2, options);
+    const rightCandidates = features.filter(f => f.maxX > 1 || f.minX >= 1);
+    const right = rightCandidates.length
+      ? clip(rightCandidates, 1, 1, 3, AxisType.X, -1, 2, options)
+      : null;
     if (right) result.push(...shiftFeatureCoords(right, -1));
 
-    const left = clip(features, 1, -2, 0, AxisType.X, -1, 2, options);
+    const leftCandidates = features.filter(f => f.minX < 0);
+    const left = leftCandidates.length
+      ? clip(leftCandidates, 1, -2, 0, AxisType.X, -1, 2, options)
+      : null;
     if (left) result.push(...shiftFeatureCoords(left, 1));
 
     return result;

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -20,26 +20,20 @@ export function wrap(features: GeoJSONVTInternalFeature[], options: GeoJSONVTOpt
 
     return merged;
   } else {
-    const result: GeoJSONVTInternalFeature[] = [];
-
-    const center = clip(features, 1, 0, 1, AxisType.X, -1, 2, options);
-    if (center) result.push(...center);
-
     // Prevent duplicates at the antimeridian, because clip()'s bounds are inclusive, 
     // so features with maxX === 1 must be routed to the right pass only.
+    const leftCandidates  = features.filter(f => f.minX < 0);
     const rightCandidates = features.filter(f => f.maxX > 1 || f.minX >= 1);
-    const right = rightCandidates.length
-      ? clip(rightCandidates, 1, 1, 3, AxisType.X, -1, 2, options)
-      : null;
-    if (right) result.push(...shiftFeatureCoords(right, -1));
 
-    const leftCandidates = features.filter(f => f.minX < 0);
-    const left = leftCandidates.length
-      ? clip(leftCandidates, 1, -2, 0, AxisType.X, -1, 2, options)
-      : null;
-    if (left) result.push(...shiftFeatureCoords(left, 1));
+    const left  = leftCandidates.length  ? clip(leftCandidates,  1, -2, 0, AxisType.X, -1, 2, options) : null; // left world copy
+    const right = rightCandidates.length ? clip(rightCandidates, 1,  1, 3, AxisType.X, -1, 2, options) : null; // right world copy
 
-    return result;
+    let merged = clip(features, 1, 0, 1, AxisType.X, -1, 2, options) || []; // center world copy
+
+    if (left) merged = shiftFeatureCoords(left, 1).concat(merged); // merge left into center
+    if (right) merged = merged.concat(shiftFeatureCoords(right, -1)); // merge right into center
+
+    return merged;
   }
 }
 

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -3,7 +3,11 @@ import {AxisType, clip} from './clip';
 import type { GeoJSONVTInternalFeature, GeoJSONVTOptions, StartEndSizeArray } from './definitions';
 import {createFeature} from './feature';
 
-export function wrap(features: GeoJSONVTInternalFeature[], options: GeoJSONVTOptions): GeoJSONVTInternalFeature[] {
+export function wrap(
+  features: GeoJSONVTInternalFeature[],
+  options: GeoJSONVTOptions,
+): GeoJSONVTInternalFeature[] {
+  if (options.worldCopies) {
     const buffer = options.buffer / options.extent;
     let merged = features;
 
@@ -18,64 +22,78 @@ export function wrap(features: GeoJSONVTInternalFeature[], options: GeoJSONVTOpt
     if (right) merged = merged.concat(shiftFeatureCoords(right, -1)); // merge right into center
 
     return merged;
+  } else {
+    const result: GeoJSONVTInternalFeature[] = [];
+
+    const center = clip(features, 1, 0, 1, AxisType.X, -1, 2, options);
+    if (center) result.push(...center);
+
+    const right = clip(features, 1, 1, 3, AxisType.X, -1, 2, options);
+    if (right) result.push(...shiftFeatureCoords(right, -1));
+
+    const left = clip(features, 1, -2, 0, AxisType.X, -1, 2, options);
+    if (left) result.push(...shiftFeatureCoords(left, 1));
+
+    return result;
+  }
 }
 
 function shiftFeatureCoords(features: GeoJSONVTInternalFeature[], offset: number): GeoJSONVTInternalFeature[] {
-    const newFeatures = [];
+  const newFeatures = [];
 
-    for (const feature of features) {
-        switch (feature.type) {
+  for (const feature of features) {
+    switch (feature.type) {
             case 'Point':
             case 'MultiPoint':
             case 'LineString': {
-                const newGeometry = shiftCoords(feature.geometry, offset);
+        const newGeometry = shiftCoords(feature.geometry, offset);
 
                 newFeatures.push(createFeature(feature.id, feature.type, newGeometry, feature.tags));
-                continue;
-            }
+        continue;
+      }
 
             case 'MultiLineString':
             case 'Polygon': {
-                const newGeometry = [];
-                for (const line of feature.geometry) {
-                    newGeometry.push(shiftCoords(line, offset));
-                }
+        const newGeometry = [];
+        for (const line of feature.geometry) {
+          newGeometry.push(shiftCoords(line, offset));
+        }
 
                 newFeatures.push(createFeature(feature.id, feature.type, newGeometry, feature.tags));
-                continue;
-            }
+        continue;
+      }
 
             case 'MultiPolygon': {
-                const newGeometry = [];
-                for (const polygon of feature.geometry) {
-                    const newPolygon = [];
-                    for (const line of polygon) {
-                        newPolygon.push(shiftCoords(line, offset));
-                    }
-                    newGeometry.push(newPolygon);
-                }
+        const newGeometry = [];
+        for (const polygon of feature.geometry) {
+          const newPolygon = [];
+          for (const line of polygon) {
+            newPolygon.push(shiftCoords(line, offset));
+          }
+          newGeometry.push(newPolygon);
+        }
 
                 newFeatures.push(createFeature(feature.id, feature.type, newGeometry, feature.tags));
-                continue;
-            }
-        }
+        continue;
+      }
     }
+  }
 
-    return newFeatures;
+  return newFeatures;
 }
 
 function shiftCoords(points: StartEndSizeArray, offset: number): number[] | StartEndSizeArray {
-    const newPoints: StartEndSizeArray = [];
-    newPoints.size = points.size;
+  const newPoints: StartEndSizeArray = [];
+  newPoints.size = points.size;
 
-    if (points.start !== undefined) {
-        newPoints.start = points.start;
-        newPoints.end = points.end;
-    }
+  if (points.start !== undefined) {
+    newPoints.start = points.start;
+    newPoints.end = points.end;
+  }
 
-    for (let i = 0; i < points.length; i += 3) {
-        newPoints.push(points[i] + offset, points[i + 1], points[i + 2]);
-    }
+  for (let i = 0; i < points.length; i += 3) {
+    newPoints.push(points[i] + offset, points[i + 1], points[i + 2]);
+  }
 
-    return newPoints;
+  return newPoints;
 }

--- a/test/world-copies.test.ts
+++ b/test/world-copies.test.ts
@@ -1,0 +1,79 @@
+
+import {describe, test, expect} from 'vitest';
+import {GeoJSONVT} from '../src';
+
+function point(coordinates: [number, number]): GeoJSON.Feature<GeoJSON.Point> {
+    return {type: 'Feature', properties: {}, geometry: {type: 'Point', coordinates}};
+}
+
+function lineString(coordinates: [number, number][]): GeoJSON.Feature<GeoJSON.LineString> {
+    return {type: 'Feature', properties: {}, geometry: {type: 'LineString', coordinates}};
+}
+
+function polygon(coordinates: [number, number][][]): GeoJSON.Feature<GeoJSON.Polygon> {
+    return {type: 'Feature', properties: {}, geometry: {type: 'Polygon', coordinates}};
+}
+
+describe('worldCopies: true', () => {
+    test('line crossing antimeridian is duplicated with buffer overlap', () => {
+        const vt = new GeoJSONVT(lineString([[170, 0], [190, 0]]));
+        const tile = vt.getTile(0, 0, 0);
+        expect(tile.features.length).toBe(2);
+    });
+});
+
+describe('worldCopies: false', () => {
+    test('line crossing antimeridian is clipped without overlap', () => {
+        const vt = new GeoJSONVT(lineString([[170, 0], [190, 0]]), {
+            worldCopies: false,
+        });
+        const tile = vt.getTile(0, 0, 0);
+        expect(tile.features.length).toBe(2);
+    });
+
+    test('polygon crossing antimeridian is split into two', () => {
+        const vt = new GeoJSONVT(polygon([[
+            [170, 10], [190, 10], [190, -10], [170, -10], [170, 10]
+        ]]), {
+            worldCopies: false,
+        });
+        const tile = vt.getTile(0, 0, 0);
+        expect(tile.features.length).toBe(2);
+        expect(tile.features[0].type).toBe(3);
+        expect(tile.features[1].type).toBe(3);
+    });
+
+    test('point at exactly 180° is preserved', () => {
+        const vt = new GeoJSONVT(point([180, 0]), {
+            worldCopies: false,
+        });
+        const tile = vt.getTile(0, 0, 0);
+        expect(tile.features.length).toBe(1);
+    });
+
+    test('point at 540° is shifted back', () => {
+        const vt = new GeoJSONVT(point([540, 0]), {
+            worldCopies: false,
+        });
+        const tile = vt.getTile(0, 0, 0);
+        expect(tile.features.length).toBe(1);
+    });
+
+    test('works at higher zoom levels', () => {
+        const vt = new GeoJSONVT(polygon([[
+            [170, 10], [190, 10], [190, -10], [170, -10], [170, 10]
+        ]]), {
+            worldCopies: false,
+            maxZoom: 2,
+            indexMaxZoom: 2,
+        });
+
+        const rightEdgeTile = vt.getTile(2, 3, 1);
+        expect(rightEdgeTile).not.toBeNull();
+        expect(rightEdgeTile.features.length).toBeGreaterThan(0);
+
+        const leftEdgeTile = vt.getTile(2, 0, 1);
+        expect(leftEdgeTile).not.toBeNull();
+        expect(leftEdgeTile.features.length).toBeGreaterThan(0);
+    });
+});

--- a/test/world-copies.test.ts
+++ b/test/world-copies.test.ts
@@ -1,6 +1,9 @@
-
 import {describe, test, expect} from 'vitest';
 import {GeoJSONVT} from '../src';
+import { defaultOptions } from '../src/geojsonvt';
+
+const EXTENT = defaultOptions.extent;
+const BUFFER = defaultOptions.buffer;
 
 function point(coordinates: [number, number]): GeoJSON.Feature<GeoJSON.Point> {
     return {type: 'Feature', properties: {}, geometry: {type: 'Point', coordinates}};
@@ -14,75 +17,122 @@ function polygon(coordinates: [number, number][][]): GeoJSON.Feature<GeoJSON.Pol
     return {type: 'Feature', properties: {}, geometry: {type: 'Polygon', coordinates}};
 }
 
+function multiPolygon(coordinates: [number, number][][][]): GeoJSON.Feature<GeoJSON.MultiPolygon> {
+    return {type: 'Feature', properties: {}, geometry: {type: 'MultiPolygon', coordinates}};
+}
+
+function xRange(feature: {geometry: unknown}): [number, number] {
+    const xs = (feature.geometry as [number, number][][]).flat().map(([x]) => x);
+    return [Math.min(...xs), Math.max(...xs)];
+}
+
 describe('worldCopies: true', () => {
-    test('line crossing antimeridian is duplicated with buffer overlap', () => {
+    test('line crossing antimeridian is duplicated into both world copies', () => {
         const vt = new GeoJSONVT(lineString([[170, 0], [190, 0]]));
         const tile = vt.getTile(0, 0, 0);
         expect(tile.features.length).toBe(2);
     });
+
+    test('polygon crossing antimeridian is duplicated with buffer overlap on both sides', () => {
+        const vt = new GeoJSONVT(polygon([[
+            [170, 10], [190, 10], [190, -10], [170, -10], [170, 10]
+        ]]));
+        const tile = vt.getTile(0, 0, 0);
+        expect(tile.features.length).toBe(2);
+
+        const ranges = tile.features.map(xRange);
+        const east = ranges.find(([, max]) => max > EXTENT);
+        const west = ranges.find(([min]) => min < 0);
+        expect(east).toBeDefined();
+        expect(west).toBeDefined();
+    });
 });
 
 describe('worldCopies: false', () => {
-    test('line crossing antimeridian is clipped without overlap', () => {
-        const vt = new GeoJSONVT(lineString([[170, 0], [190, 0]]), {
-            worldCopies: false,
-        });
-        const tile = vt.getTile(0, 0, 0);
-        expect(tile.features.length).toBe(2);
+    test('point just past antimeridian is not duplicated in the east buffer', () => {
+        const tile = new GeoJSONVT(point([181, 0]), {worldCopies: false}).getTile(0, 0, 0);
+        expect(tile.features.length).toBe(1);
+        const [tx] = (tile.features[0].geometry as [number, number][])[0];
+        expect(tx).toBeGreaterThanOrEqual(0);
+        expect(tx).toBeLessThan(BUFFER);
     });
 
-    test('polygon crossing antimeridian is split into two', () => {
+    test('line ending at antimeridian has no buffer overshoot', () => {
+        const tile = new GeoJSONVT(lineString([[170, 0], [180, 0]]), {worldCopies: false}).getTile(0, 0, 0);
+        expect(tile.features.length).toBe(1);
+        const [min, max] = xRange(tile.features[0]);
+        expect(min).toBeGreaterThanOrEqual(0);
+        expect(max).toBe(EXTENT);
+    });
+
+    test('polygon crossing antimeridian splits into two pieces inside [0, EXTENT]', () => {
         const vt = new GeoJSONVT(polygon([[
             [170, 10], [190, 10], [190, -10], [170, -10], [170, 10]
-        ]]), {
-            worldCopies: false,
-        });
+        ]]), {worldCopies: false});
         const tile = vt.getTile(0, 0, 0);
         expect(tile.features.length).toBe(2);
         expect(tile.features[0].type).toBe(3);
         expect(tile.features[1].type).toBe(3);
-    });
 
-    test('line touching 180 degrees exactly is not duplicated', () => {
-        const vt = new GeoJSONVT(lineString([[170, 0], [180, 0]]), {
-            worldCopies: false,
-        });
-        const tile = vt.getTile(0, 0, 0);
-        expect(tile.features.length).toBe(1);
+        for (const feature of tile.features) {
+            const [min, max] = xRange(feature);
+            expect(min).toBeGreaterThanOrEqual(0);
+            expect(max).toBeLessThanOrEqual(EXTENT);
+        }
     });
 
     test('polygon touching 180 degrees exactly is not duplicated', () => {
         const vt = new GeoJSONVT(polygon([[
             [170, 10], [180, 10], [180, -10], [170, -10], [170, 10]
-        ]]), {
-            worldCopies: false,
-        });
+        ]]), {worldCopies: false});
         const tile = vt.getTile(0, 0, 0);
         expect(tile.features.length).toBe(1);
     });
 
     test('line touching -180 degrees exactly is not duplicated', () => {
-        const vt = new GeoJSONVT(lineString([[-180, 0], [-170, 0]]), {
-            worldCopies: false,
-        });
+        const vt = new GeoJSONVT(lineString([[-180, 0], [-170, 0]]), {worldCopies: false});
         const tile = vt.getTile(0, 0, 0);
         expect(tile.features.length).toBe(1);
     });
 
     test('point at exactly 180 degrees is preserved', () => {
-        const vt = new GeoJSONVT(point([180, 0]), {
-            worldCopies: false,
-        });
+        const vt = new GeoJSONVT(point([180, 0]), {worldCopies: false});
         const tile = vt.getTile(0, 0, 0);
         expect(tile.features.length).toBe(1);
     });
 
-    test('point at 540 degrees is shifted back', () => {
-        const vt = new GeoJSONVT(point([540, 0]), {
-            worldCopies: false,
-        });
+    test('point at 540 degrees is wrapped to the antimeridian in the central world', () => {
+        const vt = new GeoJSONVT(point([540, 0]), {worldCopies: false});
         const tile = vt.getTile(0, 0, 0);
         expect(tile.features.length).toBe(1);
+        const [tx] = (tile.features[0].geometry as [number, number][])[0];
+        expect([0, EXTENT]).toContain(tx);
+    });
+
+    test('point at -540 degrees is wrapped to the antimeridian in the central world', () => {
+        const vt = new GeoJSONVT(point([-540, 0]), {worldCopies: false});
+        const tile = vt.getTile(0, 0, 0);
+        expect(tile.features.length).toBe(1);
+        const [tx] = (tile.features[0].geometry as [number, number][])[0];
+        expect([0, EXTENT]).toContain(tx);
+    });
+
+    test('MultiPolygon with one crossing and one contained polygon stays inside [0, EXTENT]', () => {
+        const vt = new GeoJSONVT(multiPolygon([
+            [[[170, 10], [190, 10], [190, -10], [170, -10], [170, 10]]],
+            [[[0, 20], [20, 20], [20, 0], [0, 0], [0, 20]]],
+        ]), {worldCopies: false});
+        const tile = vt.getTile(0, 0, 0);
+
+        expect(tile.features.length).toBe(2);
+        expect(tile.features[0].type).toBe(3);
+        expect(tile.features[1].type).toBe(3);
+
+        for (const feature of tile.features) {
+            const [min, max] = xRange(feature);
+            expect(min).toBeGreaterThanOrEqual(0);
+            expect(max).toBeLessThanOrEqual(EXTENT);
+        }
     });
 
     test('works at higher zoom levels', () => {

--- a/test/world-copies.test.ts
+++ b/test/world-copies.test.ts
@@ -43,7 +43,33 @@ describe('worldCopies: false', () => {
         expect(tile.features[1].type).toBe(3);
     });
 
-    test('point at exactly 180° is preserved', () => {
+    test('line touching 180 degrees exactly is not duplicated', () => {
+        const vt = new GeoJSONVT(lineString([[170, 0], [180, 0]]), {
+            worldCopies: false,
+        });
+        const tile = vt.getTile(0, 0, 0);
+        expect(tile.features.length).toBe(1);
+    });
+
+    test('polygon touching 180 degrees exactly is not duplicated', () => {
+        const vt = new GeoJSONVT(polygon([[
+            [170, 10], [180, 10], [180, -10], [170, -10], [170, 10]
+        ]]), {
+            worldCopies: false,
+        });
+        const tile = vt.getTile(0, 0, 0);
+        expect(tile.features.length).toBe(1);
+    });
+
+    test('line touching -180 degrees exactly is not duplicated', () => {
+        const vt = new GeoJSONVT(lineString([[-180, 0], [-170, 0]]), {
+            worldCopies: false,
+        });
+        const tile = vt.getTile(0, 0, 0);
+        expect(tile.features.length).toBe(1);
+    });
+
+    test('point at exactly 180 degrees is preserved', () => {
         const vt = new GeoJSONVT(point([180, 0]), {
             worldCopies: false,
         });
@@ -51,7 +77,7 @@ describe('worldCopies: false', () => {
         expect(tile.features.length).toBe(1);
     });
 
-    test('point at 540° is shifted back', () => {
+    test('point at 540 degrees is shifted back', () => {
         const vt = new GeoJSONVT(point([540, 0]), {
             worldCopies: false,
         });

--- a/test/world-copies.test.ts
+++ b/test/world-copies.test.ts
@@ -1,6 +1,6 @@
 import {describe, test, expect} from 'vitest';
 import {GeoJSONVT} from '../src';
-import { defaultOptions } from '../src/geojsonvt';
+import {defaultOptions} from '../src/geojsonvt';
 
 const EXTENT = defaultOptions.extent;
 const BUFFER = defaultOptions.buffer;

--- a/test/world-copies.test.ts
+++ b/test/world-copies.test.ts
@@ -1,5 +1,5 @@
 import {describe, test, expect} from 'vitest';
-import {GeoJSONVT} from '../src';
+import {GeoJSONVT, GEOJSONVT_ANTIMERIDIAN_CLIP} from '../src';
 import {defaultOptions} from '../src/geojsonvt';
 
 const EXTENT = defaultOptions.extent;
@@ -45,6 +45,16 @@ describe('worldCopies: true', () => {
         const west = ranges.find(([min]) => min < 0);
         expect(east).toBeDefined();
         expect(west).toBeDefined();
+    });
+
+    test('antimeridian-crossing polygon is not tagged with GEOJSONVT_ANTIMERIDIAN_CLIP', () => {
+        const vt = new GeoJSONVT(polygon([[
+            [170, 10], [190, 10], [190, -10], [170, -10], [170, 10]
+        ]]));
+        const tile = vt.getTile(0, 0, 0);
+        for (const feature of tile.features) {
+            expect(feature.tags?.[GEOJSONVT_ANTIMERIDIAN_CLIP]).toBeUndefined();
+        }
     });
 });
 
@@ -151,5 +161,45 @@ describe('worldCopies: false', () => {
         const leftEdgeTile = vt.getTile(2, 0, 1);
         expect(leftEdgeTile).not.toBeNull();
         expect(leftEdgeTile.features.length).toBeGreaterThan(0);
+    });
+
+    test('antimeridian-crossing polygon is tagged with GEOJSONVT_ANTIMERIDIAN_CLIP on both edge tiles', () => {
+        const vt = new GeoJSONVT(polygon([[
+            [170, 10], [190, 10], [190, -10], [170, -10], [170, 10]
+        ]]), {worldCopies: false});
+        const tile = vt.getTile(0, 0, 0);
+        expect(tile.features.length).toBe(2);
+        for (const feature of tile.features) {
+            expect(feature.tags?.[GEOJSONVT_ANTIMERIDIAN_CLIP]).toBe(true);
+        }
+    });
+
+    test('non-crossing polygon is NOT tagged', () => {
+        const vt = new GeoJSONVT(polygon([[
+            [10, 10], [30, 10], [30, -10], [10, -10], [10, 10]
+        ]]), {worldCopies: false});
+        const tile = vt.getTile(0, 0, 0);
+        expect(tile.features.length).toBe(1);
+        expect(tile.features[0].tags?.[GEOJSONVT_ANTIMERIDIAN_CLIP]).toBeUndefined();
+    });
+
+    test('antimeridian-crossing polygon tag propagates to interior tiles at higher zoom', () => {
+        // Polygon spans longitudes 170 to 190 — at z=2 it covers tiles x=0 (left edge),
+        // x=3 (right edge), and (after wrap) potentially adjacent interior tiles.
+        // We assert the tag is present on every tile that contains a piece of it.
+        const vt = new GeoJSONVT(polygon([[
+            [170, 10], [190, 10], [190, -10], [170, -10], [170, 10]
+        ]]), {
+            worldCopies: false,
+            maxZoom: 2,
+            indexMaxZoom: 2,
+        });
+        for (const x of [0, 3]) {
+            const tile = vt.getTile(2, x, 1);
+            expect(tile).not.toBeNull();
+            for (const feature of tile.features) {
+                expect(feature.tags?.[GEOJSONVT_ANTIMERIDIAN_CLIP]).toBe(true);
+            }
+        }
     });
 });


### PR DESCRIPTION
This is the first part of the alternative approach discussed [here](https://github.com/maplibre/maplibre-gl-js/pull/6970) to fix https://github.com/maplibre/maplibre-gl-js/issues/6248. 
It adds a `worldCopies` option, which makes it possible to disable the wrapping of features, required for maplibre projections where it doesn't make sense (e.g. globe projection) and where it leads to visual issues (like the double rendering of features crossing the antimeridian).

Regarding the original issue, this can be manually tested in isolation (i.e. without any changes to maplibre aside from overriding the `geojson-vt` dependency) by changing the default value of `worldCopies` to `false` and then viewing the code from the codepen demo. With this the overlap/double rendering will be generally gone, but we now have a line and/or stroke at the antimeridian, because we essentially render two features, one on the left and one on the right:

<img width="1586" height="1382" alt="image" src="https://github.com/user-attachments/assets/fbf1c05e-37f4-4b32-a5b0-e98315492e17" />

To get rid of these artefacts changes to maplibre are required, which I'll open a PR for soon.
 
---

This is certainly not my area of expertise, so please let me know if there is anything to change or improve.