### PR TITLE
Replace spread operator usage

### DIFF
--- a/src/difference.ts
+++ b/src/difference.ts
@@ -165,7 +165,7 @@ function getUpdatedFeatures(vtFeatures: GeoJSONVTInternalFeature[], update: GeoJ
     if (changeProps) {
         const updated = [];
         for (const vtFeature of vtFeatures) {
-            const feature = {...vtFeature};
+            const feature = Object.assign({}, vtFeature);
             feature.tags = applyPropertyUpdates(feature.tags, update);
             updated.push(feature);
         }
@@ -183,7 +183,7 @@ function applyPropertyUpdates(tags: GeoJSON.GeoJsonProperties, update: GeoJSONVT
         return {};
     }
 
-    const properties = {...tags || {}};
+    const properties = Object.assign({}, tags || {});
 
     if (update.removeProperties) {
         for (const key of update.removeProperties) {


### PR DESCRIPTION
This replaces two uses of the (object) spread operator that had made their way into the maplibre-gl-js worker thread bundle with appropriate `Object.assign` calls. They had been causing errors (`__spreadValues is not defined`) when bundled with esbuild, specifically when performing diff updates.

See maplibre/maplibre-gl-js#6429 (a similar issue) for more information.